### PR TITLE
Refactor/google token refresh (#7)

### DIFF
--- a/src/main/java/com/example/Easeplan/api/Calendar/service/GoogleOAuthService.java
+++ b/src/main/java/com/example/Easeplan/api/Calendar/service/GoogleOAuthService.java
@@ -83,57 +83,8 @@ public class GoogleOAuthService {
         }
     }
 
-    // JWT 토큰 검증 메서드
-    public boolean isValidGoogleJwtToken(String accessToken) {
-        try {
-            // GoogleIdTokenVerifier 객체 생성
-            NetHttpTransport transport = GoogleNetHttpTransport.newTrustedTransport();
-            JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
 
-            // GoogleIdTokenVerifier 설정
-            GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory)
-                    .setAudience(Collections.singletonList(googleOAuthProperties.getWebClientId()))  // 클라이언트 ID로 검증
-                    .build();
 
-            // JWT 토큰 검증
-            GoogleIdToken idToken = verifier.verify(accessToken);
-            if (idToken != null) {
-                log.info("Google JWT Token is valid.");
-                return true;
-            } else {
-                log.warn("Invalid Google JWT token.");
-                return false;
-            }
-        } catch (Exception e) {
-            log.error("Error verifying Google JWT token", e);
-            return false;
-        }
-    }
-
-    // Google JWT에서 이메일을 추출
-    public String getEmailFromGoogleJwtToken(String token) {
-        try {
-            // GoogleIdTokenVerifier 객체 생성
-            NetHttpTransport transport = GoogleNetHttpTransport.newTrustedTransport();
-            JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
-
-            // GoogleIdTokenVerifier 설정
-            GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory)
-                    .setAudience(Collections.singletonList(googleOAuthProperties.getWebClientId()))  // 클라이언트 ID로 검증
-                    .build();
-
-            // GoogleIdToken을 사용하여 토큰을 검증
-            GoogleIdToken idToken = verifier.verify(token);
-            if (idToken != null) {
-                return idToken.getPayload().getEmail(); // 이메일 추출
-            } else {
-                throw new RuntimeException("Invalid Google JWT token.");
-            }
-        } catch (Exception e) {
-            log.error("Error extracting email from Google JWT token", e);
-            throw new RuntimeException("Error extracting email from Google JWT token", e);
-        }
-    }
 
     // JWT에서 이메일을 추출하는 메서드
 

--- a/src/main/java/com/example/Easeplan/global/auth/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/Easeplan/global/auth/exception/GlobalExceptionHandler.java
@@ -1,20 +1,25 @@
-//package com.example.Easeplan.global.auth.exception;
-//
-//import org.springframework.http.HttpStatus;
-//import org.springframework.web.bind.annotation.ControllerAdvice;
-//import org.springframework.web.bind.annotation.ExceptionHandler;
-//import org.springframework.http.ResponseEntity;
-//import lombok.extern.slf4j.Slf4j;
-//import org.springframework.web.bind.annotation.RestControllerAdvice;
-//
-//@Slf4j
-//@RestControllerAdvice
-//public class GlobalExceptionHandler {
-//    @ExceptionHandler(Exception.class)
-//    public ResponseEntity<String> handleAllExceptions(Exception ex) {
-//        log.error("서버 예외 발생", ex);
-//        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-//                .body("서버 오류가 발생했습니다: " + ex.getMessage());
-//    }
-//}
-//
+package com.example.Easeplan.global.auth.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 내부 예외 클래스
+    public static class GoogleRelinkRequiredException extends RuntimeException {
+        public GoogleRelinkRequiredException() {
+            super("Google account needs to be relinked.");
+        }
+        public GoogleRelinkRequiredException(Throwable cause) {
+            super("Google account needs to be relinked.", cause);
+        }
+    }
+
+    @ExceptionHandler(GoogleRelinkRequiredException.class)
+    public ResponseEntity<String> handleGoogleRelinkRequired(GoogleRelinkRequiredException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    }
+}


### PR DESCRIPTION
## 📋 작업 내용

- Google Calendar API 연동 시 액세스 토큰 만료 체크 및 자동 갱신 로직 구현

- 401 Unauthorized 발생 시 토큰 재갱신 후 1회 재시도 메서드(withRetry401) 추가

- 토큰 만료 시각을 UTC LocalDateTime으로 변환하여 DB 반영

- Refresh Token이 없거나 무효(invalid_grant)일 경우 GoogleRelinkRequiredException 발생

- GlobalExceptionHandler에서 해당 예외를 HTTP 401 응답으로 전역 처리

---

## 📌 변경 이유 또는 배경

- Refresh Token 이슈 발생 시 명확하게 예외를 던져 프론트에서 재연동 흐름으로 유도하기 위함


---

## ✅ 작업 완료 내용 
- [ ] getCalendarService()에서 토큰 만료시 refreshIfExpired()로 자동 갱신

- [ ] 401 에러 발생 시 withRetry401로 한 번 더 재시도

- [ ] 토큰과 만료 시각 DB 저장 로직 수정(UTC 기준)

- [ ] GoogleRelinkRequiredException 생성 및 GlobalExceptionHandler 처리 로직 구현


---

## 📸 스크린샷 (필요 시)


---

## 🔗 관련 이슈 링크
- #7 

---

## 📝 기타

- 프론트에서는 HTTP 401 + "Google account needs to be relinked." 응답 시 구글 OAuth 재연동 페이지로 유도 필요

