### PR TITLE
Feat/swagger multi env (#16)

### DIFF
--- a/src/main/java/com/example/Easeplan/global/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/Easeplan/global/auth/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.Easeplan.global.auth.service.JwtAuthenticationFilter;
 import jakarta.annotation.PostConstruct;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -42,10 +43,11 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.addAllowedOriginPattern("*"); // 모든 오리진 허용
-        config.addAllowedHeader("*");
-        config.addAllowedMethod("*");
+        config.setAllowedOriginPatterns(List.of("http://localhost:*", "http://127.0.0.1:*", "https://recommend.ai.kr"));
+        config.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of("Authorization"));
+
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
@@ -61,6 +63,7 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
                                 "/error", "/callback.html", "/static/**", "/error/**",
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**",
@@ -70,7 +73,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers(
                                 "/api/survey/select", "/api/survey/scenarios", "/api/short-recommend", "/api/haru/**","/api/long-recommend/**",
-                                "/api/fcm/**", "/api/mypage/**", "/api/devices/latest", "/api/fcm/register","/api/crawl/**","/api/weekly/**","/api/monthly/**","/api/tour/location","api/tour/detail"
+                                "/api/fcm/**", "/api/mypage/**", "/api/devices/latest", "/api/fcm/register","/api/crawl/**","/api/weekly/**","/api/monthly/**","/api/tour/location","/api/tour/detail"
                         ).authenticated()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/Easeplan/global/auth/config/SwaggerConfig.java
+++ b/src/main/java/com/example/Easeplan/global/auth/config/SwaggerConfig.java
@@ -1,35 +1,34 @@
 package com.example.Easeplan.global.auth.config;
 
-import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.*;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.servers.Server;      // <-- 서버 URL 명시를 위한 import
+import io.swagger.v3.oas.models.security.*;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.List;                               // <-- 여러 서버 URL을 위한 import
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .components(new Components().addSecuritySchemes("accessToken",
+                .components(new Components().addSecuritySchemes(
+                        "bearerAuth",
                         new SecurityScheme()
                                 .type(SecurityScheme.Type.HTTP)
                                 .scheme("bearer")
                                 .bearerFormat("JWT")
-                                .in(SecurityScheme.In.HEADER)
-                                .name("Authorization")
                 ))
+                //  모든 API에 토큰 자동 부착
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+                //  Same Origin + 운영 + (선택) 로컬 직접 호출 옵션
                 .servers(List.of(
+                        new Server().url("/").description("Same Origin"),           // UI 오리진 그대로
                         new Server().url("https://recommend.ai.kr").description("Production"),
-                        new Server().url("http://localhost:8080").description("Local")
+                        new Server().url("http://localhost:8080").description("Local (직접 호출)")
                 ))
-                .info(new Info()
-                        .title("NOGOROK API")
-                        .description("API 설명")
-                        .version("v1.0"));
+                .info(new Info().title("NOGOROK API").version("v1.0").description("API 설명"));
     }
 }


### PR DESCRIPTION
## 📋 작업 내용

- Swagger/OpenAPI 설정 리팩토링

   - bearerAuth HTTP Bearer 스키마 추가 및 전역 SecurityRequirement 적용 → 모든 API에 Authorization: Bearer <token> 자동 부착

   - servers 다중 환경 등록: /(Same Origin), 서버, http://localhost:8080

   - (구) accessToken 스키마 제거, 표준 Bearer로 통일
   
- Spring Security 보완

   - CORS 프리플라이트(OPTIONS) 허용: .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()

   - CORS 허용 원점 보강: localhost/127.0.0.1/*, 서

   - 인증 경로 패턴 일부 슬래시 누락 수정 ("/api/tour/detail" 등)

---

## 📌 변경 이유 또는 배경

- Swagger에서 Authorize를 해도 일부 엔드포인트에 토큰 헤더가 미부착되어 403 발생 → 전역 SecurityRequirement 필요

- 운영(HTTPS) UI에서 로컬(HTTP) 호출 시 혼합콘텐츠/Failed to fetch 발생 → Same Origin 서버 등록으로 회피

- 프리플라이트(OPTIONS) 401/403로 인해 CORS 핸드셰이크 실패 → OPTIONS 허용 및 CORS 설정 강화

---

## ✅ 작업 완료 내용 

- [x]  bearerAuth 스키마 및 전역 SecurityRequirement 적용

- [x]   servers에 /, prod, local 등록

- [x]   CORS/OPTIONS 설정 보완 및 경로 패턴 정리

- [x]   로컬/운영 환경에서 Swagger UI로 요청 검증(토큰 자동 부착, 200 응답 확인)



---

## 🔗 관련 이슈 링크
- #16 
---

## 📝 기타
- 테스트 방법

로컬: http://localhost:8080/swagger-ui/index.html 접속 → Servers에서 / (Same Origin) 선택

운영: https://recommend.ai.kr/swagger-ui/index.html 접속 → / (Same Origin) 또는 Production 선택

Authorize에서 토큰만 입력(접두어 Bearer 금지) → API 실행 → 200 확인


- 주의사항 / 리스크 & 롤백

운영(HTTPS) UI에서 로컬(HTTP) 서버 선택 시 브라우저가 혼합콘텐츠로 차단됨 → 로컬 테스트는 로컬 UI에서 진행

문제 발생 시 임시 롤백: Swagger servers를 "/"만 남겨 동일 오리진으로 제한

Postman/서버 간 동작은 영향 없음(브라우저 CORS/Swagger 한정 변경)
