### PR TITLE
Feat/emergency fcm (#6)

### DIFF
--- a/src/main/java/com/example/Easeplan/api/Emergency/controller/EmergencyController.java
+++ b/src/main/java/com/example/Easeplan/api/Emergency/controller/EmergencyController.java
@@ -1,0 +1,145 @@
+package com.example.Easeplan.api.Emergency.controller;
+
+import com.example.Easeplan.api.Emergency.domain.EmergencyStressEvent;
+import com.example.Easeplan.api.Emergency.repository.EmergencyStressEventRepository;
+import com.example.Easeplan.api.Emergency.service.ShortBreakWriter;
+import com.example.Easeplan.api.ShortFlask.service.FlaskRecommendService;
+import com.example.Easeplan.api.Survey.domain.UserSurvey;
+import com.example.Easeplan.api.Survey.dto.UserSurveyRequest;
+import com.example.Easeplan.api.Survey.service.UserSurveyService;
+import com.example.Easeplan.global.auth.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Tag(name = "Emergency Stress", description = "긴급 스트레스 모드 관련 API")
+
+@RestController
+@RequestMapping("/api/emergency-stress")
+@RequiredArgsConstructor
+public class EmergencyController {
+
+    private final EmergencyStressEventRepository eventRepository;
+    private final UserSurveyService surveyService;
+    private final FlaskRecommendService flaskService;
+    private final ShortBreakWriter shortBreakWriter;
+
+    /**
+     * 앱 시작 시 PENDING 이벤트 존재 여부 확인 → 있으면 전용 화면 띄우기
+     */
+    @Operation(
+            summary = "앱 실행 시: 대기(PENDING) 중인 긴급 스트레스 이벤트 확인",
+            description = """
+프론트에서 **앱 실행 직후(또는 포그라운드 복귀 시) 1회** 호출해,
+사용자가 푸시를 놓쳤더라도 긴급 스트레스 안내 화면을 띄울 수 있도록 합니다.
+
+[언제 호출하나요?]
+- 앱 콜드 스타트 직후 시 1회
+
+
+[무엇을 응답하나요?]
+- **pending = true**: 아직 활성화되지 않은(PENDING) 이벤트가 존재
+  - 함께 내려오는 **eventId**로 전용 화면을 열고, 활성화 버튼에서
+    `POST /api/emergency-stress/{eventId}/activate` 호출
+- **pending = false**: 처리할 이벤트 없음(전용 화면 미표시)
+
+[주의/동작 규칙]
+- 한 사용자에 대해 PENDING은 1건만 존재한다고 가정합니다.
+- 사용자가 활성화에 성공하면 해당 이벤트는 ACTIVATED로 바뀌고,
+  이후 이 API는 **pending=false**를 반환합니다.
+"""
+
+    )
+    @GetMapping("/pending")
+    public ResponseEntity<?> hasPending(@AuthenticationPrincipal User me) {
+        return eventRepository
+                .findTopByUserAndStatusOrderByCreatedAtDesc(me, EmergencyStressEvent.Status.PENDING)
+                .map(ev -> ResponseEntity.ok(Map.of(
+                        "pending", true,
+                        "eventId", ev.getId()
+                )))
+                .orElseGet(() -> ResponseEntity.ok(Map.of(
+                        "pending", false
+                )));
+    }
+
+
+    /**
+     * 활성화 버튼 클릭(딥링크/화면 버튼) → 오늘 포함 3일 배정
+     */
+
+    @Operation(
+            summary = "긴급 스트레스 모드 활성화(멱등)",
+            description = """
+**특정 eventId**의 긴급 스트레스 이벤트를 **PENDING → ACTIVATED**로 전환하고, 
+**오늘 포함 3일간 '짧은 쉼표' 일정을 자동 배정**합니다.
+
+### 동작 요약
+- 상태가 **PENDING** 인 경우에만 활성화가 수행되며, 배정 로직이 실행됩니다.
+- **이미 ACTIVATED** 된 같은 이벤트(eventId)에 대해 **중복 호출**되면,
+  일정은 **추가 생성하지 않고** 200 OK("이미 활성화 처리되었습니다.")만 반환합니다. (멱등)
+
+### 클라이언트 권장 흐름
+- FCM data-only에 포함된 `deeplink`(예: `nogorok://stress/chronic?eventId=...`)로 페이지 진입
+- 쿼리의 `eventId`를 사용해 본 API 호출
+- 만약 eventId를 못 받았다면 `/pending`으로 조회 후 얻은 eventId 사용
+
+※ 활성화 시 설문 정보가 없으면 일정 배정은 생략하고 상태만 ACTIVATED로 바뀝니다.
+"""
+
+    )
+    @PostMapping("/{eventId}/activate")
+    @Transactional
+    public ResponseEntity<?> activate(@AuthenticationPrincipal User me, @PathVariable Long eventId) {
+        EmergencyStressEvent event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid eventId"));
+
+        if (!event.getUser().getId().equals(me.getId())) {
+            return ResponseEntity.status(403).body("권한이 없습니다.");
+        }
+
+        // 멱등 처리: 이미 ACTIVATED면 OK로 응답
+        if (event.getStatus() == EmergencyStressEvent.Status.ACTIVATED) {
+            return ResponseEntity.ok("이미 활성화 처리되었습니다.");
+        }
+        if (event.getStatus() != EmergencyStressEvent.Status.PENDING) {
+            return ResponseEntity.badRequest().body("처리할 수 없는 이벤트 상태입니다.");
+        }
+
+        // 설문 로드 (null 대비)
+        UserSurvey survey = surveyService.getSurveyByUser(me);
+        if (survey == null) {
+            // 설문이 없으면 일정만 생략하고 상태만 ACTIVATED로 바꿔도 됨
+            event.markActivated();
+            eventRepository.save(event);
+            return ResponseEntity.ok("설문 정보가 없어 일정을 배정하지 않았지만, 활성화는 완료되었습니다.");
+        }
+
+        UserSurveyRequest req = UserSurveyRequest.fromEntity(survey);
+        List<String> dailyTitles = flaskService.getRecommendations(req).stream()
+                .filter(s -> s != null && !s.isBlank())
+                .distinct()
+                .limit(3)
+                // .collect(Collectors.toList()); // Java 11
+                .toList();                         // Java 16+
+
+        if (!dailyTitles.isEmpty()) {
+            shortBreakWriter.createShortBreakNDays(me, LocalDate.now(), dailyTitles);
+        }
+
+        event.markActivated();
+        eventRepository.save(event);
+
+        return ResponseEntity.ok("긴급 스트레스 모드를 활성화했고, 오늘 포함 3일간 짧은 쉼표를 배정했습니다.");
+    }
+
+}
+

--- a/src/main/java/com/example/Easeplan/api/Emergency/domain/EmergencyStressEvent.java
+++ b/src/main/java/com/example/Easeplan/api/Emergency/domain/EmergencyStressEvent.java
@@ -1,0 +1,33 @@
+package com.example.Easeplan.api.Emergency.domain;
+
+import com.example.Easeplan.global.auth.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter @Builder
+@NoArgsConstructor @AllArgsConstructor
+public class EmergencyStressEvent {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    private Status status; // PENDING → (사용자 확인 전), ACTIVATED → (활성화 버튼 클릭), EXPIRED → (만료/무시)
+
+    private LocalDateTime createdAt;
+    private LocalDateTime activatedAt;
+
+    public enum Status { PENDING, ACTIVATED, EXPIRED }
+
+    public void markActivated() {
+        this.status = Status.ACTIVATED;
+        this.activatedAt = LocalDateTime.now();
+    }
+
+    public void expire() { this.status = Status.EXPIRED; }
+}

--- a/src/main/java/com/example/Easeplan/api/Emergency/repository/EmergencyStressEventRepository.java
+++ b/src/main/java/com/example/Easeplan/api/Emergency/repository/EmergencyStressEventRepository.java
@@ -1,0 +1,11 @@
+package com.example.Easeplan.api.Emergency.repository;
+
+import com.example.Easeplan.api.Emergency.domain.EmergencyStressEvent;
+import com.example.Easeplan.global.auth.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmergencyStressEventRepository extends JpaRepository<EmergencyStressEvent, Long> {
+    Optional<EmergencyStressEvent> findTopByUserAndStatusOrderByCreatedAtDesc(User user, EmergencyStressEvent.Status status);
+}

--- a/src/main/java/com/example/Easeplan/api/Emergency/service/EmergencyStressService.java
+++ b/src/main/java/com/example/Easeplan/api/Emergency/service/EmergencyStressService.java
@@ -1,0 +1,101 @@
+package com.example.Easeplan.api.Emergency.service;
+
+import com.example.Easeplan.api.Emergency.domain.EmergencyStressEvent;
+import com.example.Easeplan.api.Emergency.repository.EmergencyStressEventRepository;
+import com.example.Easeplan.api.Fcm.service.FcmService;
+import com.example.Easeplan.api.SmartWatch.domain.HeartRate;
+import com.example.Easeplan.api.SmartWatch.repository.SmartwatchRepository;
+
+import com.example.Easeplan.global.auth.domain.User;
+import com.example.Easeplan.global.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+
+@Service
+@RequiredArgsConstructor
+public class EmergencyStressService {
+
+    private static final int WINDOW_DAYS = 14;
+    private static final int MIN_HIGH_DAYS = 11;
+    private static final double THRESHOLD = 70.0;
+
+    private final UserRepository userRepository;
+    private final SmartwatchRepository smartwatchRepository;
+    private final FcmService fcmService;
+    private final EmergencyStressEventRepository eventRepository;
+
+    private static final DateTimeFormatter F = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+    @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul") //1h
+    @Transactional
+    public void evaluateAllUsersAndTrigger() {
+        LocalDate today = LocalDate.now();
+        LocalDate endDate = today.minusDays(1);
+
+        for (User user : userRepository.findAll()) {
+            if (!user.isPushNotificationAgreed()) continue;
+
+            int highDays = countHighStressDays(user, endDate);
+            if (highDays < MIN_HIGH_DAYS || !shouldSendFcm(user, today)) continue;
+
+            // 이미 PENDING 이벤트가 있다면 중복 생성 방지(선택)
+            boolean hasPending = eventRepository
+                    .findTopByUserAndStatusOrderByCreatedAtDesc(user, EmergencyStressEvent.Status.PENDING)
+                    .isPresent();
+            if (hasPending) continue;
+
+            // 1) 이벤트 생성(PENDING)
+            var event = EmergencyStressEvent.builder()
+                    .user(user)
+                    .status(EmergencyStressEvent.Status.PENDING)
+                    .createdAt(java.time.LocalDateTime.now())
+                    .build();
+            eventRepository.save(event);
+
+            // 2) FCM 발송 (활성화 여부 묻기)
+            if (user.getFcmTokens() != null) {
+                for (String token : user.getFcmTokens()) {
+                    try { fcmService.sendEmergencyStressAsk(token, event.getId()); } catch (Exception ignored) {}
+                }
+            }
+
+            // 3) 2주 재전송 방지
+            user.setLastAutoBreakFcmSentAt(today);
+            userRepository.save(user);
+        }
+    }
+
+    private int countHighStressDays(User user, LocalDate endDate) {
+        int highDays = 0;
+        for (int i = 0; i < WINDOW_DAYS; i++) {
+            LocalDate target = endDate.minusDays(i);
+            var day = smartwatchRepository.findByUserAndStartTimeBetween(
+                    user,
+                    target.atStartOfDay().format(F),
+                    target.atTime(23, 59, 59).format(F)
+            );
+
+            if (day.isEmpty()) continue;
+
+            double dailyAvg = day.stream()
+                    .filter(hr -> hr.getAvg() != null)
+                    .mapToDouble(HeartRate::getAvg)
+                    .average()
+                    .orElse(0.0);
+
+            if (dailyAvg >= THRESHOLD) highDays++;
+        }
+        return highDays;
+    }
+
+    private boolean shouldSendFcm(User user, LocalDate today) {
+        return user.getLastAutoBreakFcmSentAt() == null
+                || user.getLastAutoBreakFcmSentAt().isBefore(today.minusDays(14));
+    }
+}

--- a/src/main/java/com/example/Easeplan/api/Emergency/service/ShortBreakWriter.java
+++ b/src/main/java/com/example/Easeplan/api/Emergency/service/ShortBreakWriter.java
@@ -1,0 +1,98 @@
+package com.example.Easeplan.api.Emergency.service;
+
+import com.example.Easeplan.api.Calendar.dto.TimeSlot;
+import com.example.Easeplan.api.Calendar.service.GoogleCalendarService;
+import com.example.Easeplan.global.auth.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.*;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ShortBreakWriter {
+
+    private final GoogleCalendarService calendarService;
+
+    @Transactional
+    public void createShortBreakNDays(User user, LocalDate startDateInclusive, List<String> dailyTitles) {
+        ZoneId ZONE = ZoneId.of("Asia/Seoul");
+        LocalTime DAY_START = LocalTime.of(8, 0);
+        LocalTime DAY_END   = LocalTime.of(22, 0);
+
+        for (int i = 0; i < dailyTitles.size(); i++) {
+            LocalDate day = startDateInclusive.plusDays(i);
+            String title = dailyTitles.get(i);
+
+            int minutes = parseMinutes(title); // "(30분)" → 30, 없으면 60으로 가정
+
+            // 1) 빈 슬롯 조회
+            List<TimeSlot> free;
+            try {
+                free = calendarService.getFreeTimeSlots(user, day);
+            } catch (Exception e) {
+                // 캘린더 조회 실패 → 폴백
+                addEventFallback(user, day, title, minutes);
+                continue;
+            }
+
+            // 2) 08~22시 사이에서 'minutes' 이상 확보되는 가장 이른 슬롯 찾기
+            ZonedDateTime start = null, end = null;
+            for (TimeSlot ts : free) {
+                ZonedDateTime s = Instant.ofEpochMilli(ts.getStart().getValue()).atZone(ZONE);
+                ZonedDateTime e = Instant.ofEpochMilli(ts.getEnd().getValue()).atZone(ZONE);
+
+                // 업무시간으로 클립
+                ZonedDateTime minStart = day.atTime(DAY_START).atZone(ZONE);
+                ZonedDateTime maxEnd   = day.atTime(DAY_END).atZone(ZONE);
+                if (s.isBefore(minStart)) s = minStart;
+                if (e.isAfter(maxEnd)) e = maxEnd;
+
+                // 유효 & 길이 체크
+                if (e.isAfter(s) && Duration.between(s, e).toMinutes() >= minutes) {
+                    start = s;
+                    end = s.plusMinutes(minutes);
+                    break;
+                }
+            }
+
+            if (start == null) {
+                // 3) 폴백 10:00~(minutes)
+                addEventFallback(user, day, title, minutes);
+            } else {
+                addEvent(user, title, start, end);
+            }
+        }
+    }
+
+    private int parseMinutes(String title) {
+        var m = java.util.regex.Pattern.compile("\\((\\d+)분\\)").matcher(title);
+        return m.find() ? Integer.parseInt(m.group(1)) : 60;
+    }
+
+    private void addEventFallback(User user, LocalDate day, String title, int minutes) {
+        ZoneId ZONE = ZoneId.of("Asia/Seoul");
+        ZonedDateTime s = day.atTime(10, 0).atZone(ZONE);
+        ZonedDateTime e = s.plusMinutes(minutes);
+        addEvent(user, title, s, e);
+    }
+
+    private void addEvent(User user, String title, ZonedDateTime start, ZonedDateTime end) {
+        try {
+            String startRfc3339 = start.toOffsetDateTime().toString();
+            String endRfc3339   = end.toOffsetDateTime().toString();
+            calendarService.addEvent(
+                    user, "primary",
+                    title,
+                    "설문 기반 추천", // 또는 "잠깐 쉬어가요 😊"
+                    startRfc3339, endRfc3339,
+                    false, 0, false, false, "emergency"
+            );
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION
## 📋 작업 내용

- 긴급 스트레스 모드 구현
  - 14일 중 11일 이상 스트레스 지수가 70 이상일 경우, 새벽 1시에 자동으로 PENDING 이벤트 생성 및 FCM 발송
  - 사용자가 FCM 알림을 클릭하거나 앱 실행 시 `/pending` API를 통해 이벤트 존재 여부 확인
  - 활성화 버튼을 누르면 이벤트 상태를 `ACTIVATED`로 전환하고, 오늘 포함 3일간 짧은 쉼표 일정 자동 배정

---

## 📌 변경 이유 또는 배경

- 스트레스 지수가 장기간 높을 경우 자동 개입이 필요했음
- 단순 알림만으로는 놓칠 수 있어 `/pending` API를 추가하여 앱 실행 시에도 긴급 모드를 유도
- 기존 짧은 쉼표 추천 로직을 재활용하되, 긴급 모드의 경우 `sourceType = emergency`로 구분하여 관리 필요

---

## ✅ 작업 완료 내용 (필수 작성)

- [x] `EmergencyStressEvent` 엔티티 및 Repository 구현
- [x] 새벽 1시 조건 검사 스케줄러 구현 (`EmergencyStressService`)
- [x] FCM data-only 발송 로직 추가 (`type`, `eventId`, `deeplink`)
- [x] `/pending` API 구현 
- [x] `/activate` API 구현 (3일간 짧은 쉼표 자동 배정 및 이벤트 상태 변경)
- [x] `ShortBreakWriter`에서 `sourceType=emergency` 분기 처리

---

## 📸 스크린샷

---

## 🔗 관련 이슈 링크

- closed #6 

---

## 📝 기타

- `/pending` API는 앱 실행 시 1회 호출을 전제로 하며, FCM 알림을 놓친 경우에도 전용 화면으로 유도하기 위한 보조 용도입니다.
- 활성화 버튼을 누르면 `ACTIVATED` 상태로 전환되며, 오늘 포함 3일 간 짧은 쉼표 일정이 자동 배정됩니다.
