### PR TITLE
Test/emergency

### DIFF
--- a/src/main/java/com/example/Easeplan/api/Fcm/controller/FcmController.java
+++ b/src/main/java/com/example/Easeplan/api/Fcm/controller/FcmController.java
@@ -7,6 +7,10 @@ import com.example.Easeplan.api.Fcm.service.FcmService;
 import com.example.Easeplan.global.auth.domain.User;
 import com.example.Easeplan.global.auth.repository.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -34,24 +38,96 @@ public class FcmController {
         this.notificationRepo = notificationRepo;
     }
 
-    // 1) FCM 토큰 등록
-    @Operation(summary = "FCM 토큰 등록", description = "사용자의 FCM 토큰을 서버에 저장합니다.")
-    @PostMapping("/register")
-    public ResponseEntity<Void> registerFcmToken(
+    // 1) FCM 토큰 등록 (+ 유효성 검증)
+    @Operation(
+            summary = "FCM 토큰 등록(+유효성 검증)",
+            description = "토큰을 FCM dry-run으로 검증한 뒤, 유효하면 사용자 계정에 저장합니다. "
+                    + "기본적으로 validate=true이며, 무효 토큰이면 422(Unprocessable Entity)로 이유를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "등록 성공(유효성 검증 통과)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(name = "성공",
+                                    value = """
+                {
+                  "registered": true,
+                  "validated": true,
+                  "validation": {
+                    "ok": true,
+                    "dryRun": true,
+                    "messageId": "projects/<proj>/messages/xxxxx"
+                  }
+                }
+                """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "422",
+                    description = "무효 토큰(UNREGISTERED/INVALID_ARGUMENT 등) — 저장하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(name = "무효 토큰(UNREGISTERED)",
+                                    value = """
+                {
+                  "registered": false,
+                  "validated": true,
+                  "validation": {
+                    "ok": false,
+                    "dryRun": true,
+                    "code": "UNREGISTERED",
+                    "errorCode": "NOT_FOUND",
+                    "msg": "Requested entity was not found.",
+                    "httpStatus": 404,
+                    "httpBody": "{\\n  \\"error\\": {\\n    \\"code\\": 404,\\n    \\"message\\": \\"Requested entity was not found.\\",\\n    \\"status\\": \\"NOT_FOUND\\",\\n    \\"details\\": [\\n      {\\n        \\"@type\\": \\"type.googleapis.com/google.firebase.fcm.v1.FcmError\\",\\n        \\"errorCode\\": \\"UNREGISTERED\\"\\n      }\\n    ]\\n  }\\n}\\n"
+                  }
+                }
+                """
+                            )
+                    )
+            )})
+        @PostMapping("/register")
+    public ResponseEntity<?> registerFcmToken(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestParam String token
+            @RequestParam String token,
+            @RequestParam(defaultValue = "true") boolean validate
     ) {
         User user = userRepository.findByEmail(userDetails.getUsername())
                 .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Map<String, Object> validation = null;
+        if (validate) {
+            validation = fcmService.validateToken(token);
+            if (!Boolean.TRUE.equals(validation.get("ok"))) {
+                // 저장하지 않고 422 + 실패사유 반환
+                return ResponseEntity.unprocessableEntity().body(
+                        Map.of(
+                                "registered", false,
+                                "validated", true,
+                                "validation", validation
+                        )
+                );
+            }
+        }
+
+        // 유효하면 저장 (idempotent 가정)
         user.addFcmToken(token);
         userRepository.save(user);
-        return ResponseEntity.ok().build();
+
+        return ResponseEntity.ok(
+                Map.of(
+                        "registered", true,
+                        "validated", validate,
+                        "validation", validation
+                )
+        );
     }
 
-    // 2) 예약 알림 등록 (세터 없이 저장)
-    @Operation(
-            summary = "예약 알림 등록",
-            description = """
+    // 2) 예약 알림 등록
+    @Operation(summary = "예약 알림 등록", description = """
         사용자가 설정한 시간에 FCM 알림을 예약합니다.<br>
         <b>헤더에 accessToken을 포함해야 합니다.</b><br><br>
         요청 본문:
@@ -59,14 +135,12 @@ public class FcmController {
           "title": "회의 시작 알림",
           "startDateTime": "2025-05-20T14:00:00+09:00",
           "minutesBeforeAlarm": 10
-        }"""
-    )
+        }""")
     @PostMapping("/schedule")
     public ResponseEntity<?> scheduleNotification(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody NotificationScheduleRequest request
     ) {
-        // 기본 검증
         if (request.title() == null || request.title().isBlank()) {
             return ResponseEntity.badRequest().body("title은 필수입니다.");
         }
@@ -95,7 +169,6 @@ public class FcmController {
             return ResponseEntity.badRequest().body("알림 시간이 현재보다 이후가 되도록 minutesBeforeAlarm을 조정하세요.");
         }
 
-        // 세터 없이 빌더로 생성
         ScheduledNotification notification = ScheduledNotification.builder()
                 .title(request.title())
                 .fcmToken(fcmToken)
@@ -113,15 +186,21 @@ public class FcmController {
         );
     }
 
-    // 3) 단건 테스트 발송
-    @Operation(summary = "테스트 FCM 발송")
+    // 3) 단건 테스트 발송/검증 (dryRun=true면 유효성만)
+    @Operation(summary = "테스트 FCM 발송(또는 유효성 검사)")
     @GetMapping("/test-send")
-    public ResponseEntity<?> testSend(
-            @AuthenticationPrincipal UserDetails userDetails,
-            @RequestParam String token
-    ) {
-        boolean ok = fcmService.sendMessage(token, "백엔드 테스트", "서버에서 FCM 보내기 성공!");
-        return ok ? ResponseEntity.ok("FCM 전송 성공")
-                : ResponseEntity.status(502).body("FCM 전송 실패");
+    public ResponseEntity<?> testSendDebug(@RequestParam String token,
+                                           @RequestParam(defaultValue = "false") boolean dryRun) {
+        Map<String, Object> out = fcmService.sendMessageDebug(
+                token, "백엔드 테스트", "debug send", Map.of("type", "DEBUG"), dryRun);
+        return Boolean.TRUE.equals(out.get("ok")) ? ResponseEntity.ok(out)
+                : ResponseEntity.status(502).body(out);
+    }
+
+    // (선택) 전용 유효성 체크
+    @Operation(summary = "FCM 토큰 유효성 검사(dry-run)")
+    @GetMapping("/validate")
+    public ResponseEntity<?> validate(@RequestParam String token) {
+        return ResponseEntity.ok(fcmService.validateToken(token));
     }
 }


### PR DESCRIPTION
## 📋 작업 내용

- FCM 토큰 등록 API 개선

  - /api/fcm/register 호출 시 dry-run으로 토큰 유효성 검증 후, 유효할 때만 저장

  - 무효 토큰(예: UNREGISTERED)은 저장하지 않고 422로 상세 사유 반환

- 유효성 점검/테스트 유틸 추가

  - GET /api/fcm/validate?token=... : 토큰 유효성만 검사(dry-run)

  - GET /api/fcm/test-send?token=...&dryRun=... : 실발송/드라이런 겸용 디버그

- 에러 디테일 표준화

  - 응답에 code(예: UNREGISTERED), errorCode, httpStatus, httpBody 포함
---

## 📌 변경 이유 또는 배경

- 푸시 테스트 중 UNREGISTERED 토큰으로 인한 502/404 빈발

- 프론트가 즉시 복구할 명확한 신호(422 + 사유) 필요

- 잘못된 토큰 저장 방지로 운영 안정성/전송 성공률 향상

---

## ✅ 작업 완료 내용 
- [ ] 스웨거 문서: 성공/실패 예시 응답 추가


---

## 📸 스크린샷 
- 무효 토큰 등록 시도 → 422 확인
<img width="881" height="438" alt="image" src="https://github.com/user-attachments/assets/15859f3c-5cef-4ff2-81bb-e5d7bbd5df53" />

---

## 🔗 관련 이슈 링크
- #26

