### PR TITLE
Fix/auth

### DIFF
--- a/src/main/java/com/example/Easeplan/global/auth/service/AuthService.java
+++ b/src/main/java/com/example/Easeplan/global/auth/service/AuthService.java
@@ -86,7 +86,6 @@ public class AuthService {
     }
 
 
-
     @Transactional
     public TokenResponse signIn(SignInRequest request) {
         User user = userRepository.findByEmail(request.getEmail())

--- a/src/main/java/com/example/Easeplan/global/auth/service/AuthService.java
+++ b/src/main/java/com/example/Easeplan/global/auth/service/AuthService.java
@@ -89,36 +89,43 @@ public class AuthService {
 
     @Transactional
     public TokenResponse signIn(SignInRequest request) {
-        User user = userRepository.findByEmail(request.getEmail())  // 수정된 메서드 호출
+        User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
-        // 1. 구글 액세스 토큰 갱신 (리프레시 토큰으로)
+        // (선택) 구글 액세스 토큰 갱신: 연동 안됐거나 만료면 예외가 올라오게 두고,
+        // 로그인 자체는 계속 진행하려면 try/catch로 감싸서 null 허용하세요.
         String newGoogleAccessToken = oAuthService.getOrRefreshGoogleAccessToken(user);
 
-        // 2. 리프레시 토큰과 함께 새로운 JWT 발급
-        RefreshToken refreshTokenEntity = refreshTokenRepository.findByEmail(user.getEmail())
-                .orElseThrow(() -> new IllegalArgumentException("토큰이 존재하지 않습니다."));
-        String refreshToken = refreshTokenEntity.getToken();
-        String accessToken = "";
+        //  refresh_token 레코드 Self-heal: 없으면 새로 생성
+        RefreshToken rt = refreshTokenRepository.findByEmail(user.getEmail())
+                .orElseGet(() -> refreshTokenRepository.save(
+                        RefreshToken.builder()
+                                .user(user)
+                                .email(user.getEmail())
+                                .token(jwtUtil.createRefreshToken(user))
+                                .build()
+                ));
 
+        String refreshToken = rt.getToken();
+        String accessToken;
         if (jwtUtil.isValidRefreshToken(refreshToken)) {
             accessToken = jwtUtil.createAccessToken(user);
         } else {
             refreshToken = jwtUtil.createRefreshToken(user);
-            refreshTokenEntity.updateToken(refreshToken);
+            rt.updateToken(refreshToken);
             accessToken = jwtUtil.createAccessToken(user);
         }
 
-        // 구글 액세스 토큰을 포함한 응답 반환
         return TokenResponse.builder()
-                .accessToken(accessToken)         // 자체 애플리케이션의 액세스 토큰
-                .refreshToken(refreshToken)       // 애플리케이션의 리프레시 토큰
-                .googleAccessToken(newGoogleAccessToken)  // 구글 액세스 토큰
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .googleAccessToken(newGoogleAccessToken)
                 .build();
     }
+
 
 
 


### PR DESCRIPTION
## 📋 작업 내용

- 로그인 시 refresh_token 레코드가 없으면 자동 생성(Self-heal) 하여 "토큰이 존재하지 않습니다." 400 오류를 예방

- 첫 로그인/스키마 초기화 후(ddl-auto create)에도 정상 로그인 가능하게 수정

- 기존 로직 유지: 유효한 리프레시 토큰이면 재사용, 만료/무효면 재발급

---

## 📌 변경 이유 또는 배경

- DB 초기화나 마이그레이션 과정에서 refresh_token 테이블이 비면, 기존 사용자가 로그인 시 400 오류가 발생

- 운영 편의/복구성 향상을 위해 로그인 시점에 누락 토큰을 자동 보정하도록 개선

---

## ✅ 작업 완료 내용 
- [x] AuthService.signIn에서 사용자 리프레시 토큰 조회→없으면 생성/저장

- [x]  리프레시 토큰 유효성 체크 및 재발급 로직 정리

- [x]  예외 메시지/경계 케이스 점검 (유저 없음, 비밀번호 불일치, 토큰 만료)

- [x]  로컬/개발 환경 수동 테스트 (초기화 상태 → 첫 로그인 시 정상 발급 확인)
---

## 📸 스크린샷 
### 기존 로그인 시 리프레시 토큰 없는 경우
<img width="967" height="292" alt="image" src="https://github.com/user-attachments/assets/98b0410b-ce76-4d67-98c1-80a9c4304c89" />

### 리팩토링 후 로그인
<img width="941" height="210" alt="image" src="https://github.com/user-attachments/assets/c8e32581-7158-44df-a821-54436a049440" />


---

## 🔗 관련 이슈 링크
- #8 

